### PR TITLE
Nftmkt 4123 adminのリストをゲットできるような関数

### DIFF
--- a/contracts/access/Admin.sol
+++ b/contracts/access/Admin.sol
@@ -13,6 +13,11 @@ abstract contract Admin is Context {
   mapping(address => bool) private _admin;
 
   /**
+   * @dev 管理者のリスト
+   */
+  address[] private _adminList;
+
+  /**
    * @dev デプロイ時にデプロイ者を管理者に追加する。
    */
   constructor() {
@@ -45,6 +50,11 @@ abstract contract Admin is Context {
       "Admin:addAdmin newAdmin is the zero address"
     );
 
+    // 管理者のリストにまだ追加されていなければ追加
+    if (!_admin[newAdmin]) {
+      _adminList.push(newAdmin);
+    }
+
     _admin[newAdmin] = true;
     emit AdminAdded(newAdmin);
   }
@@ -67,6 +77,18 @@ abstract contract Admin is Context {
    */
   function _removeAdmin(address admin) internal virtual {
     delete _admin[admin];
+
+    // 該当の管理者を削除した配列を生成する
+    address[] memory newAdminList = new address[](_adminList.length - 1);
+    uint256 count = 0;
+    for (uint256 i = 0; i < _adminList.length; i++) {
+      if (_admin[_adminList[i]]) {
+        newAdminList[count] = _adminList[i];
+        count++;
+      }
+    }
+    _adminList = newAdminList;
+
     emit AdminRemoved(admin);
   }
 
@@ -76,6 +98,14 @@ abstract contract Admin is Context {
    */
   function isAdmin(address checkAdmin) public view virtual returns (bool) {
     return _admin[checkAdmin];
+  }
+
+  /**
+   * @dev
+   * Adminのリストを取得
+   */
+  function getAdminList() public view virtual returns (address[] memory) {
+    return _adminList;
   }
 
   /**

--- a/contracts/upgradeable/access/AdminUpgradeable.sol
+++ b/contracts/upgradeable/access/AdminUpgradeable.sol
@@ -12,6 +12,8 @@ abstract contract AdminUpgradeable is ContextUpgradeable {
    */
   mapping(address => bool) private _admin;
 
+  address[] private _adminList;
+
   function __Admin_init() internal onlyInitializing {
     __Context_init();
     // 初期化時にデプロイ者を管理者に追加する。
@@ -44,7 +46,12 @@ abstract contract AdminUpgradeable is ContextUpgradeable {
       "Admin:addAdmin newAdmin is the zero address"
     );
 
+    if (!_admin[newAdmin]) {
+      _adminList.push(newAdmin);
+    }
+
     _admin[newAdmin] = true;
+
     emit AdminAdded(newAdmin);
   }
 
@@ -56,7 +63,6 @@ abstract contract AdminUpgradeable is ContextUpgradeable {
       _admin[admin],
       "Admin:removeAdmin trying to remove non existing Admin"
     );
-
     _removeAdmin(admin);
   }
 
@@ -66,6 +72,15 @@ abstract contract AdminUpgradeable is ContextUpgradeable {
    */
   function _removeAdmin(address admin) internal virtual {
     delete _admin[admin];
+    address[] memory newAdminList = new address[](_adminList.length - 1);
+    uint256 count = 0;
+    for (uint256 i = 0; i < _adminList.length; i++) {
+      if (!_admin[_adminList[i]]) {
+        newAdminList[count] = _adminList[i];
+        count++;
+      }
+    }
+    _adminList = newAdminList;
     emit AdminRemoved(admin);
   }
 
@@ -75,6 +90,14 @@ abstract contract AdminUpgradeable is ContextUpgradeable {
    */
   function isAdmin(address checkAdmin) public view virtual returns (bool) {
     return _admin[checkAdmin];
+  }
+
+  /**
+   * @dev
+   * Adminのリストを取得
+   */
+  function getAdminList() public view virtual returns (address[] memory) {
+    return _adminList;
   }
 
   /**

--- a/contracts/upgradeable/access/AdminUpgradeable.sol
+++ b/contracts/upgradeable/access/AdminUpgradeable.sol
@@ -12,6 +12,9 @@ abstract contract AdminUpgradeable is ContextUpgradeable {
    */
   mapping(address => bool) private _admin;
 
+  /**
+   * @dev 管理者のリスト
+   */
   address[] private _adminList;
 
   function __Admin_init() internal onlyInitializing {
@@ -46,6 +49,7 @@ abstract contract AdminUpgradeable is ContextUpgradeable {
       "Admin:addAdmin newAdmin is the zero address"
     );
 
+    // 管理者のリストにまだ追加されていなければ追加
     if (!_admin[newAdmin]) {
       _adminList.push(newAdmin);
     }
@@ -72,15 +76,18 @@ abstract contract AdminUpgradeable is ContextUpgradeable {
    */
   function _removeAdmin(address admin) internal virtual {
     delete _admin[admin];
+
+    // 該当の管理者を削除した配列を生成する
     address[] memory newAdminList = new address[](_adminList.length - 1);
     uint256 count = 0;
     for (uint256 i = 0; i < _adminList.length; i++) {
-      if (!_admin[_adminList[i]]) {
+      if (_admin[_adminList[i]]) {
         newAdminList[count] = _adminList[i];
         count++;
       }
     }
     _adminList = newAdminList;
+
     emit AdminRemoved(admin);
   }
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "lint:sol:fix": "prettier --write .",
     "coverage": "env COVERAGE=true hardhat coverage",
     "test": "hardhat test",
+    "test-a": "hardhat test test/access/Admin.test.ts",
     "test-au": "hardhat test test/upgradeable/AdminUpgradeable.test.ts",
     "gas-report": "env REPORT_GAS=true yarn run test",
     "compile": "hardhat compile",

--- a/test/upgradeable/AdminUpgradeable.test.ts
+++ b/test/upgradeable/AdminUpgradeable.test.ts
@@ -46,6 +46,9 @@ describe("AdminUpgradeable", function () {
       expect(await cAdminUpgradeableMock.isAdmin(deployer.address)).to.equal(
         true
       );
+      expect(await cAdminUpgradeableMock.getAdminList()).to.deep.equal([
+        deployer.address,
+      ]);
     });
 
     it("non-deployer is not admin", async function () {
@@ -77,6 +80,9 @@ describe("AdminUpgradeable", function () {
       expect(
         await cAdminUpgradeableMock.isAdmin(ethers.constants.AddressZero)
       ).to.equal(false);
+      expect(await cAdminUpgradeableMock.getAdminList()).to.deep.equal([
+        deployer.address,
+      ]);
     });
 
     it("can add admin", async function () {
@@ -100,6 +106,11 @@ describe("AdminUpgradeable", function () {
       expect(await cAdminUpgradeableMock.isAdmin(address1.address)).to.equal(
         true
       );
+      expect(await cAdminUpgradeableMock.getAdminList()).to.deep.equal([
+        deployer.address,
+        address1.address,
+        address2.address,
+      ]);
     });
   });
 
@@ -139,6 +150,10 @@ describe("AdminUpgradeable", function () {
       expect(await cAdminUpgradeableMock.isAdmin(address1.address)).to.equal(
         true
       );
+      expect(await cAdminUpgradeableMock.getAdminList()).to.deep.equal([
+        deployer.address,
+        address1.address,
+      ]);
     });
   });
 
@@ -166,6 +181,10 @@ describe("AdminUpgradeable", function () {
       expect(await cAdminUpgradeableMock.isAdmin(address1.address)).to.equal(
         true
       );
+      expect(await cAdminUpgradeableMock.getAdminList()).to.deep.equal([
+        deployer.address,
+        address1.address,
+      ]);
     });
 
     it("can remove admin", async function () {
@@ -173,6 +192,7 @@ describe("AdminUpgradeable", function () {
       expect(await cAdminUpgradeableMock.isAdmin(address1.address)).to.equal(
         true
       );
+
       const reemoveAdminTx = await cAdminUpgradeableMock.removeAdmin(
         address1.address
       );
@@ -187,6 +207,65 @@ describe("AdminUpgradeable", function () {
       expect(await cAdminUpgradeableMock.isAdmin(address1.address)).to.equal(
         false
       );
+
+      expect(await cAdminUpgradeableMock.getAdminList()).to.deep.equal([
+        deployer.address,
+      ]);
+    });
+
+    it("can add removed admin again", async function () {
+      cAdminUpgradeableMock["addAdmin(address)"](address1.address);
+      expect(await cAdminUpgradeableMock.isAdmin(address1.address)).to.equal(
+        true
+      );
+
+      const reemoveAdminTx = await cAdminUpgradeableMock.removeAdmin(
+        address1.address
+      );
+
+      const receipt: ContractReceipt = await reemoveAdminTx.wait();
+      const { events } = receipt;
+
+      expect(events).to.be.an("array").to.have.lengthOf(1);
+      const eventSignature = events?.map((item) => item.eventSignature);
+      expect(eventSignature).to.include.members(["AdminRemoved(address)"]);
+
+      expect(await cAdminUpgradeableMock.isAdmin(address1.address)).to.equal(
+        false
+      );
+
+      expect(await cAdminUpgradeableMock.getAdminList()).to.deep.equal([
+        deployer.address,
+      ]);
+
+      cAdminUpgradeableMock["addAdmin(address)"](address1.address);
+      expect(await cAdminUpgradeableMock.isAdmin(address1.address)).to.equal(
+        true
+      );
+
+      expect(await cAdminUpgradeableMock.getAdminList()).to.deep.equal([
+        deployer.address,
+        address1.address,
+      ]);
+    });
+
+    it("can remove last admin", async function () {
+      const reemoveAdminTx = await cAdminUpgradeableMock.removeAdmin(
+        deployer.address
+      );
+
+      const receipt: ContractReceipt = await reemoveAdminTx.wait();
+      const { events } = receipt;
+
+      expect(events).to.be.an("array").to.have.lengthOf(1);
+      const eventSignature = events?.map((item) => item.eventSignature);
+      expect(eventSignature).to.include.members(["AdminRemoved(address)"]);
+
+      expect(await cAdminUpgradeableMock.isAdmin(deployer.address)).to.equal(
+        false
+      );
+
+      expect(await cAdminUpgradeableMock.getAdminList()).to.deep.equal([]);
     });
   });
 
@@ -208,6 +287,17 @@ describe("AdminUpgradeable", function () {
       expect(await cAdminUpgradeableMock.isAdmin(address1.address)).to.equal(
         false
       );
+    });
+  });
+
+  describe("getAdminList", function () {
+    it("get admin list", async function () {
+      cAdminUpgradeableMock["addAdmin(address)"](address1.address);
+
+      expect(await cAdminUpgradeableMock.getAdminList()).to.deep.equal([
+        deployer.address,
+        address1.address,
+      ]);
     });
   });
 });


### PR DESCRIPTION
contracts/access/Admin.sol, contracts/upgradeable/AdminUpgradeable.solに、Adminのリストをゲットする関数、getAdminListを追加

